### PR TITLE
fix: Fix 'no slug defined' warning

### DIFF
--- a/fern/docs/pages/sdks.mdx
+++ b/fern/docs/pages/sdks.mdx
@@ -48,4 +48,4 @@ bash nuget install plantstore.net
 
 ## Request a new SDK
 
-If you'd like to request an SDK for a language that we don't currently support, [let us know](/welcome.mdx#get-support). We're always looking to expand our SDK offerings and would love to hear from you.
+If you'd like to request an SDK for a language that we don't currently support, [let us know](/welcome#get-support). We're always looking to expand our SDK offerings and would love to hear from you.


### PR DESCRIPTION
Fixes `welcome.mdx has no slug defined but is referenced by docs/pages/sdks.mdx` error

<img width="591" alt="Screenshot 2024-12-17 at 10 59 50 AM" src="https://github.com/user-attachments/assets/89d6263d-ff22-4218-b148-5095508fb138" />

Link navigates correctly both before and after the change