### PR TITLE
fix: Reduce GitHub Action PR preview permissions

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -5,7 +5,9 @@ on: pull_request
 jobs:
   run:
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
`write-all` gives write access to everything, so this change only gives `read` access to `contents` and `write` to PRs